### PR TITLE
[Font Ligatures support added] Added Option (eoShowLigatures) that allows ExtTextOut to use font's ligatures

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -153,7 +153,8 @@ type
     eoSpecialLineDefaultFg,    //disables the foreground text color override when using the OnSpecialLineColor event
     eoTabIndent,               //When active <Tab> and <Shift><Tab> act as block indent, unindent when text is selected
     eoTabsToSpaces,            //Converts a tab character to a specified number of space characters
-    eoTrimTrailingSpaces       //Spaces at the end of lines will be trimmed and not saved
+    eoTrimTrailingSpaces,      //Spaces at the end of lines will be trimmed and not saved
+    eoShowLigatures            //Shows font ligatures, by default it is disabled
     );
 
   TSynEditorOptions = set of TSynEditorOption;
@@ -2929,7 +2930,7 @@ var
       end;
 
       fTextDrawer.ExtTextOut(nX, rcToken.Top, ETOOptions, rcToken,
-        PWideChar(Text), nCharsToPaint);
+        PWideChar(Text), nCharsToPaint, (eoShowLigatures in fOptions));
 
       if DoTabPainting then
       begin


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/1015823/93765464-8c174900-fbda-11ea-8bb5-ad7ebb6a92af.gif)

I don't know if this is something you would like, but most modern source code editors include support for font ligatures for special glyphs in fonts like FiraCode, Cascadia, Delugia, etc. which gives a cool look.

![Operator Mono with Ligatures – Eric L. Barnes](https://ericlbarnesblog.files.wordpress.com/2018/04/operator-mono-ssm-book.png?w=900)

I just tested only on Windows using ExtTextOutW, hopefully it can be integrated and/or modified for better usability like disabling it for selected areas, on caret line, etc.