### PR TITLE
Replace with new line in fix

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -8144,7 +8144,7 @@ var
   ptStart, ptEnd: TBufferCoord; // start and end of the search range
   ptCurrent: TBufferCoord; // current search position
   nSearchLen, nReplaceLen, n, nFound: integer;
-  nInLine: integer;
+  nInLine, nEOLCount, i: integer;
   bBackward, bFromCursor: boolean;
   bPrompt: boolean;
   bReplace, bReplaceAll: boolean;
@@ -8212,6 +8212,17 @@ begin
       if bBackward then ptEnd := CaretXY else ptStart := CaretXY;
     if bBackward then ptCurrent := ptEnd else ptCurrent := ptStart;
   end;
+  //count future line ends
+  nEOLCount := 0;
+  i := 1;
+  repeat
+    i := PosEx(WideCrLf, AReplace, i);
+    if i <> 0 then
+    begin
+      i := i + Length(WideCrLf);
+      Inc(nEolCount);
+    end;
+  until i = 0;
   // initialize the search engine
   fSearchEngine.Options := AOptions;
   fSearchEngine.Pattern := ASearch;
@@ -8302,6 +8313,9 @@ begin
               BlockEnd := ptEnd;
             end;
           end;
+          //Fix new line ends
+          if nEOLCount > 0 then
+            Inc(ptEnd.Line, nEOLCount);
         end;
         if not bReplaceAll then
           exit;

--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -8151,7 +8151,7 @@ var
   bEndUndoBlock: boolean;
   nAction: TSynReplaceAction;
   iResultOffset: Integer;
-  fixReplace: string;
+  sReplace: string;
 
   function InValidSearchRange(First, Last: Integer): Boolean;
   begin
@@ -8214,13 +8214,13 @@ begin
     if bBackward then ptCurrent := ptEnd else ptCurrent := ptStart;
   end;
   //  translate \n and \t to real chars for regular expressions
-  fixReplace := fSearchEngine.FixReplaceExpression(AReplace);
+  sReplace := fSearchEngine.PreprocessReplaceExpression(AReplace);
 
   //count line ends
   nEOLCount := 0;
   i := 1;
   repeat
-    i := PosEx(WideCrLf, fixReplace, i);
+    i := PosEx(WideCrLf, sReplace, i);
     if i <> 0 then
     begin
       i := i + Length(WideCrLf);
@@ -8281,7 +8281,7 @@ begin
         // all after prompting, turn off prompting.
         if bPrompt and Assigned(fOnReplaceText) then
         begin
-          nAction := DoOnReplaceText(ASearch, fixReplace, ptCurrent.Line, nFound);
+          nAction := DoOnReplaceText(ASearch, sReplace, ptCurrent.Line, nFound);
           if nAction = raCancel then
             exit;
         end
@@ -8304,7 +8304,7 @@ begin
             bEndUndoBlock:= true;
           end;
           // Allow advanced substition in the search engine
-          SelText := fSearchEngine.Replace(SelText, fixReplace);
+          SelText := fSearchEngine.Replace(SelText, sReplace);
           nReplaceLen := CaretX - nFound;
         end;
         // fix the caret position and the remaining results

--- a/Source/SynEditMiscClasses.pas
+++ b/Source/SynEditMiscClasses.pas
@@ -349,6 +349,7 @@ type
     procedure SetOptions(const Value: TSynSearchOptions); virtual; abstract;
   public
     function FindAll(const NewText: string): Integer; virtual; abstract;
+    function FixReplaceExpression(const AReplace: string): string; virtual; 
     function Replace(const aOccurrence, aReplacement: string): string; virtual; abstract;
     property Pattern: string read GetPattern write SetPattern;
     property ResultCount: Integer read GetResultCount;
@@ -1417,5 +1418,14 @@ begin
     ChangeKey(TempKey, S);
   end;
 end; { TBetterRegistry.OpenKeyReadOnly }
+
+{ TSynEditSearchCustom }
+
+// possibility to fix search expression before is send to SynEdit.SearchReplace()
+function TSynEditSearchCustom.FixReplaceExpression(
+  const AReplace: string): string;
+begin
+  Result := AReplace;
+end;
 
 end.

--- a/Source/SynEditMiscClasses.pas
+++ b/Source/SynEditMiscClasses.pas
@@ -349,7 +349,7 @@ type
     procedure SetOptions(const Value: TSynSearchOptions); virtual; abstract;
   public
     function FindAll(const NewText: string): Integer; virtual; abstract;
-    function FixReplaceExpression(const AReplace: string): string; virtual; 
+    function PreprocessReplaceExpression(const AReplace: string): string; virtual; 
     function Replace(const aOccurrence, aReplacement: string): string; virtual; abstract;
     property Pattern: string read GetPattern write SetPattern;
     property ResultCount: Integer read GetResultCount;
@@ -1421,8 +1421,8 @@ end; { TBetterRegistry.OpenKeyReadOnly }
 
 { TSynEditSearchCustom }
 
-// possibility to fix search expression before is send to SynEdit.SearchReplace()
-function TSynEditSearchCustom.FixReplaceExpression(
+// possibility to preprocess search expression before is send to SynEdit.SearchReplace()
+function TSynEditSearchCustom.PreprocessReplaceExpression(
   const AReplace: string): string;
 begin
   Result := AReplace;

--- a/Source/SynEditRegexSearch.pas
+++ b/Source/SynEditRegexSearch.pas
@@ -65,7 +65,7 @@ type
   public
     constructor Create(AOwner: TComponent); override;
     function FindAll(const NewText: string): Integer; override;
-    function FixReplaceExpression(const AReplace: string): string; override;    
+    function PreprocessReplaceExpression(const AReplace: string): string; override;    
     function Replace(const aOccurrence, aReplacement: string): string; override;
   end;
 
@@ -117,7 +117,7 @@ begin
 end;
 
 // replace new line and tab symbol to real chars
-function TSynEditRegexSearch.FixReplaceExpression(
+function TSynEditRegexSearch.PreprocessReplaceExpression(
   const AReplace: string): string;
 begin
   Result := StringReplace(AReplace, '\n', WideCRLF, [rfReplaceAll]);

--- a/Source/SynEditRegexSearch.pas
+++ b/Source/SynEditRegexSearch.pas
@@ -65,6 +65,7 @@ type
   public
     constructor Create(AOwner: TComponent); override;
     function FindAll(const NewText: string): Integer; override;
+    function FixReplaceExpression(const AReplace: string): string; override;    
     function Replace(const aOccurrence, aReplacement: string): string; override;
   end;
 
@@ -74,6 +75,7 @@ implementation
 
 uses
   RegularExpressionsAPI,
+  System.SysUtils,
   Consts;
 
 
@@ -105,13 +107,21 @@ end;
 constructor TSynEditRegexSearch.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
-  fOptions := [roNotEmpty];
+  fOptions := [];
 end;
 
 function TSynEditRegexSearch.FindAll(const NewText: string): Integer;
 begin
   fMatchCollection :=  RegEx.Matches(NewText);
   Result := fMatchCollection.Count;
+end;
+
+// replace new line and tab symbol to real chars
+function TSynEditRegexSearch.FixReplaceExpression(
+  const AReplace: string): string;
+begin
+  Result := StringReplace(AReplace, '\n', WideCRLF, [rfReplaceAll]);
+  Result := StringReplace(Result, '\t', #9, [rfReplaceAll]);
 end;
 
 function TSynEditRegexSearch.Replace(const aOccurrence, aReplacement: string): string;
@@ -142,9 +152,9 @@ end;
 procedure TSynEditRegexSearch.SetOptions(const Value: TSynSearchOptions);
 begin
   if ssoMatchCase in Value then
-    fOptions := [roNotEmpty]
+    fOptions := []
   else
-    fOptions := [roNotEmpty, roIgnoreCase];
+    fOptions := [roIgnoreCase];
   RegEx := TRegEx.Create(fPattern, fOptions);
   RegEx.SetAdditionalPCREOptions(PCRE_UCP);
 end;


### PR DESCRIPTION
When new lines appear in replace expression, there is necessary to move pointer in result.
Test source:
XC_VAR01 , XC_MA_P01
XC_VAR02 , XC_MA_P01
XC_VAR03 , XC_MA_P02
XC_VAR04 , XC_MA_P03

Search: ^(XC_\w+)\s*,\s*(XC_\w+)\s*$
Replace: find(\n\tVin : $1\n\tVout : $2\n );\n

@JaFi-cz
Search/replace with new line in replace expression …
af831c4
When new lines appear in replace expression, there is necessary to move pointer in result.
Test source:
XC_VAR01 , XC_MA_P01
XC_VAR02 , XC_MA_P01
XC_VAR03 , XC_MA_P02
XC_VAR04 , XC_MA_P03

Search: ^(XC_\w+)\s*,\s*(XC_\w+)\s*$
Replace: find(\n\tVin : $1\n\tVout : $2\n );\n