### PR TITLE
Wrap with right edge

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -4390,7 +4390,7 @@ begin
         if WordWrap and (eoWrapWithRightEdge in FOptions) then
           nMaxScroll := FRightEdge
         else
-	        nMaxScroll := Max(TSynEditStringList(Lines).LengthOfLongestLine, 1);
+          nMaxScroll := Max(TSynEditStringList(Lines).LengthOfLongestLine, 1);
         if nMaxScroll <= MAX_SCROLL then
         begin
           ScrollInfo.nMin := 1;
@@ -5785,7 +5785,7 @@ begin
   begin
     fRightEdge := Value;
     // when wrapping with right edge, we must rewrap when edge is changed
-		if WordWrap and (eoWrapWithRightEdge in FOptions) then
+    if WordWrap and (eoWrapWithRightEdge in fOptions) then
     begin
       fWordWrapPlugin.DisplayChanged;
       EnsureCursorPosVisible;

--- a/Source/SynEditWordWrap.pas
+++ b/Source/SynEditWordWrap.pas
@@ -174,7 +174,9 @@ end;
 
 procedure TSynWordWrapPlugin.DisplayChanged;
 begin
-  if Editor.CharsInWindow <> fMaxRowLength then
+  // we are wrapping with right edge line or with window width
+	if (eoWrapWithRightEdge in Editor.Options) and (Editor.RightEdge <> fMaxRowLength) or   
+    not (eoWrapWithRightEdge in Editor.Options) and (Editor.CharsInWindow <> fMaxRowLength) then
     Reset;
 end;
 
@@ -368,8 +370,17 @@ procedure TSynWordWrapPlugin.Reset;
 begin
   Assert(Editor.CharsInWindow >= 0);
 
-  fMaxRowLength := Editor.CharsInWindow;
-  fMinRowLength := Editor.CharsInWindow - (Editor.CharsInWindow div 3);
+	// we are wrapping with right edge line or with window width
+  if (eoWrapWithRightEdge in Editor.Options) then
+  begin
+    fMaxRowLength := Editor.RightEdge;
+    fMinRowLength := Editor.RightEdge - (Editor.RightEdge div 3);
+  end
+  else
+  begin
+    fMaxRowLength := Editor.CharsInWindow;
+    fMinRowLength := Editor.CharsInWindow - (Editor.CharsInWindow div 3);
+  end;
 
   if fMinRowLength <= 0 then
     fMinRowLength := 1;

--- a/Source/SynEditWordWrap.pas
+++ b/Source/SynEditWordWrap.pas
@@ -175,7 +175,7 @@ end;
 procedure TSynWordWrapPlugin.DisplayChanged;
 begin
   // we are wrapping with right edge line or with window width
-	if (eoWrapWithRightEdge in Editor.Options) and (Editor.RightEdge <> fMaxRowLength) or   
+  if (eoWrapWithRightEdge in Editor.Options) and (Editor.RightEdge <> fMaxRowLength) or   
     not (eoWrapWithRightEdge in Editor.Options) and (Editor.CharsInWindow <> fMaxRowLength) then
     Reset;
 end;


### PR DESCRIPTION
based on the eoWrapWithRightEdge option
WordWrap is done acording to right edge line instead of the Window width
Issue #124 