### PR TITLE
GetWordAtRowCol fix

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -8877,9 +8877,9 @@ begin
   begin
     Line := Lines[XY.Line - 1];
     Len := Length(Line);
-    if (Len > 0) and InRange(XY.Char, 1, Len + 1) then
+    Start := XY.Char;
+    if (Len > 0) and InRange(XY.Char, 1, Len + 1) and IsIdentChar(Line[Start]) then
     begin
-       Start := XY.Char;
        while (Start > 1) and IsIdentChar(Line[Start - 1]) do
           Dec(Start);
 


### PR DESCRIPTION
Simulation (| means cursor position). Text in editor:
color:|
Now return WordAtCursor. It will return "color" what is wrong