### PR TITLE
Fixing compilation in Delphi 10.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@
 *.#00
 *.pch
 *.Patch
-/__history
+__history/
+__recovery/
 
 # IDE Files	  #
 ###################

--- a/Source/SynDWrite.pas
+++ b/Source/SynDWrite.pas
@@ -34,6 +34,14 @@ Uses
   System.Generics.Collections,
   Vcl.Graphics;
 
+{$IF CompilerVersion <= 32}
+// some constants missing from old Delphi D2D1 unit
+const
+  DWRITE_WORD_WRAPPING_EMERGENCY_BREAK = 2;
+  D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT = $00000004;
+  WICBitmapInterpolationModeHighQualityCubic = $00000004;
+{$ENDIF}
+
 type
 {$REGION 'IDWriteFactory Redeclaration'}
   // Redeclaring the inteface to fix the declaration of CreateGdiCompatibleTextLayout
@@ -351,9 +359,11 @@ begin
 end;
 
 function DWGetTypography(Features: array of Integer) : IDWriteTypography;
+var
+  Feature: Integer;
 begin
   CheckOSError(TSynDWrite.DWriteFactory.CreateTypography(Result));
-  for var Feature in Features do
+  for Feature in Features do
     CheckOSError(Result.AddFontFeature(DWFontFeature(Feature, 1)));
 end;
 {$ENDREGION}

--- a/Source/SynEditWordWrap.pas
+++ b/Source/SynEditWordWrap.pas
@@ -363,9 +363,11 @@ function TSynWordWrapPlugin.PrepareLine(const S: string): string;
   - DWrite ignores white space at the end of the line and this is a trick
     around this.
 }
+var
+  I: Integer;
 begin
   Result := S;
-  for var I := 1 to S.Length do
+  for I := 1 to S.Length do
   begin
     if not (Word(Result[I]) in [9, 32]) and Editor.IsWordBreakChar(Result[I]) then
       Result[I] := '-';


### PR DESCRIPTION
With this patch it compiles and seems running OK. However there is still a warning:  [dcc32 Warning] SynDWrite.pas(1): W1025 Unsupported language feature: 'class destructor'