### PR TITLE
Paint is based entirely on DirectWrite and Direct2D

### DIFF
--- a/Demos/EditAppDemos/frmEditor.dfm
+++ b/Demos/EditAppDemos/frmEditor.dfm
@@ -4,7 +4,7 @@ object EditorForm: TEditorForm
   ActiveControl = SynEditor
   Caption = 'Editor'
   ClientHeight = 287
-  ClientWidth = 454
+  ClientWidth = 448
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
@@ -22,7 +22,7 @@ object EditorForm: TEditorForm
   object SynEditor: TSynEdit
     Left = 0
     Top = 0
-    Width = 454
+    Width = 448
     Height = 287
     Align = alClient
     Font.Charset = DEFAULT_CHARSET
@@ -41,10 +41,10 @@ object EditorForm: TEditorForm
     Gutter.Font.Height = -11
     Gutter.Font.Name = 'Courier New'
     Gutter.Font.Style = []
+    Gutter.Font.Quality = fqClearTypeNatural
     Gutter.Bands = <
       item
         Kind = gbkMarks
-        Visible = True
         Width = 15
       end
       item
@@ -55,10 +55,11 @@ object EditorForm: TEditorForm
       end
       item
         Kind = gbkMargin
-        Visible = True
         Width = 2
       end>
+    Options = [eoAutoIndent, eoDragDropEditing, eoEnhanceEndKey, eoGroupUndo, eoHideShowScrollbars, eoScrollPastEol, eoShowScrollHint, eoSmartTabDelete, eoTabIndent, eoTabsToSpaces, eoShowLigatures]
     SearchEngine = SynEditSearch1
+    SelectedColor.Alpha = 0.400000005960464500
     OnChange = SynEditorChange
     OnReplaceText = SynEditorReplaceText
     OnStatusChange = SynEditorStatusChange

--- a/Demos/EditAppDemos/frmMainSDI.dfm
+++ b/Demos/EditAppDemos/frmMainSDI.dfm
@@ -1,6 +1,5 @@
 inherited SDIMainForm: TSDIMainForm
   Caption = 'Single Document Edit Demo'
-  OldCreateOrder = True
   OnCloseQuery = FormCloseQuery
   PixelsPerInch = 96
   TextHeight = 13

--- a/Demos/EditAppDemos/frmMainSDI.pas
+++ b/Demos/EditAppDemos/frmMainSDI.pas
@@ -42,7 +42,7 @@ interface
 
 uses
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
-  frmMain, Menus, uEditAppIntfs, ComCtrls, ActnList;
+  frmMain, Menus, uEditAppIntfs, ComCtrls, ActnList, System.Actions;
 
 type
   TSDIMainForm = class(TMainForm)

--- a/Demos/SearchReplaceDemo/frmMain.dfm
+++ b/Demos/SearchReplaceDemo/frmMain.dfm
@@ -2,8 +2,8 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
   Left = 100
   Top = 122
   Caption = 'Search and replace demo'
-  ClientHeight = 345
-  ClientWidth = 554
+  ClientHeight = 343
+  ClientWidth = 550
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
@@ -16,8 +16,8 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
   object SynEditor: TSynEdit
     Left = 0
     Top = 26
-    Width = 554
-    Height = 300
+    Width = 550
+    Height = 298
     Align = alClient
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -30,12 +30,12 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
     Gutter.Font.Charset = DEFAULT_CHARSET
     Gutter.Font.Color = clWindowText
     Gutter.Font.Height = -11
-    Gutter.Font.Name = 'Terminal'
+    Gutter.Font.Name = 'Consolas'
     Gutter.Font.Style = []
+    Gutter.Font.Quality = fqClearTypeNatural
     Gutter.Bands = <
       item
         Kind = gbkMarks
-        Visible = True
         Width = 15
       end
       item
@@ -46,9 +46,10 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
       end
       item
         Kind = gbkMargin
-        Visible = True
         Width = 2
       end>
+    Options = [eoAutoIndent, eoDragDropEditing, eoEnhanceEndKey, eoGroupUndo, eoHideShowScrollbars, eoScrollPastEol, eoShowScrollHint, eoSmartTabDelete, eoTabIndent, eoTabsToSpaces, eoShowLigatures]
+    SelectedColor.Alpha = 0.400000005960464500
     OnReplaceText = SynEditorReplaceText
     RemovedKeystrokes = <
       item
@@ -64,7 +65,7 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
   object ToolBarMain: TToolBar
     Left = 0
     Top = 0
-    Width = 554
+    Width = 550
     Height = 26
     AutoSize = True
     BorderWidth = 1
@@ -114,8 +115,8 @@ object SearchReplaceDemoForm: TSearchReplaceDemoForm
   end
   object Statusbar: TStatusBar
     Left = 0
-    Top = 326
-    Width = 554
+    Top = 324
+    Width = 550
     Height = 19
     Panels = <>
     SimplePanel = True

--- a/Demos/SimpleIDEDemo/frmMain.dfm
+++ b/Demos/SimpleIDEDemo/frmMain.dfm
@@ -98,6 +98,7 @@ object SimpleIDEMainForm: TSimpleIDEMainForm
     Gutter.Font.Height = -11
     Gutter.Font.Name = 'Courier New'
     Gutter.Font.Style = []
+    Gutter.Font.Quality = fqClearTypeNatural
     Gutter.Bands = <
       item
         Kind = gbkMarks
@@ -106,7 +107,7 @@ object SimpleIDEMainForm: TSimpleIDEMainForm
       item
         Kind = gbkCustom
         Width = 13
-        OnPaintLines = PaintDebugImages
+        OnPaintLines = SynEditorTSynGutterBands1PaintLines
         OnCLick = ClickDebugBand
         OnMouseCursor = SynEditorTSynGutterBands1MouseCursor
       end
@@ -115,7 +116,6 @@ object SimpleIDEMainForm: TSimpleIDEMainForm
       end
       item
         Kind = gbkFold
-        Visible = False
       end
       item
         Kind = gbkMargin
@@ -124,6 +124,7 @@ object SimpleIDEMainForm: TSimpleIDEMainForm
     Highlighter = SynPasSyn
     Options = [eoAutoIndent, eoKeepCaretX, eoScrollByOneLess, eoSmartTabs, eoTabsToSpaces, eoTrimTrailingSpaces]
     ReadOnly = True
+    SelectedColor.Alpha = 0.400000005960464500
     OnSpecialLineColors = SynEditorSpecialLineColors
   end
   object Statusbar: TStatusBar

--- a/Source/SynEditMiscProcs.pas
+++ b/Source/SynEditMiscProcs.pas
@@ -108,10 +108,6 @@ function EnumHighlighterAttris(Highlighter: TSynCustomHighlighter;
 // Calculates Frame Check Sequence (FCS) 16-bit Checksum (as defined in RFC 1171)
 function CalcFCS(const ABuf; ABufSize: Cardinal): Word;
 {$ENDIF}
-procedure SynDrawGradient(const ACanvas: TCanvas;
-  const AStartColor, AEndColor: TColor; ASteps: Integer; const ARect: TRect;
-  const AHorizontal: Boolean);
-
 function DeleteTypePrefixAndSynSuffix(s: string): string;
 function CeilOfIntDiv(Dividend, Divisor: Cardinal): Integer;
 
@@ -659,63 +655,6 @@ begin
   Result := CurFCS;
 end;
 {$ENDIF}
-
-procedure SynDrawGradient(const ACanvas: TCanvas;
-  const AStartColor, AEndColor: TColor; ASteps: Integer; const ARect: TRect;
-  const AHorizontal: Boolean);
-var
-  StartColorR, StartColorG, StartColorB: Byte;
-  DiffColorR, DiffColorG, DiffColorB: Integer;
-  i, Size: Integer;
-  PaintRect: TRect;
-begin
-  StartColorR := GetRValue(ColorToRGB(AStartColor));
-  StartColorG := GetGValue(ColorToRGB(AStartColor));
-  StartColorB := GetBValue(ColorToRGB(AStartColor));
-
-  DiffColorR := GetRValue(ColorToRGB(AEndColor)) - StartColorR;
-  DiffColorG := GetGValue(ColorToRGB(AEndColor)) - StartColorG;
-  DiffColorB := GetBValue(ColorToRGB(AEndColor)) - StartColorB;
-
-  ASteps := MinMax(ASteps, 2, 256);
-
-  if AHorizontal then
-  begin
-    Size := ARect.Right - ARect.Left;
-    PaintRect.Top := ARect.Top;
-    PaintRect.Bottom := ARect.Bottom;
-
-    for i := 0 to ASteps - 1 do
-    begin
-      PaintRect.Left := ARect.Left + MulDiv(i, Size, ASteps);
-      PaintRect.Right := ARect.Left + MulDiv(i + 1, Size, ASteps);
-
-      ACanvas.Brush.Color := RGB(StartColorR + MulDiv(i, DiffColorR,
-        ASteps - 1), StartColorG + MulDiv(i, DiffColorG, ASteps - 1),
-        StartColorB + MulDiv(i, DiffColorB, ASteps - 1));
-
-      ACanvas.FillRect(PaintRect);
-    end;
-  end
-  else
-  begin
-    Size := ARect.Bottom - ARect.Top;
-    PaintRect.Left := ARect.Left;
-    PaintRect.Right := ARect.Right;
-
-    for i := 0 to ASteps - 1 do
-    begin
-      PaintRect.Top := ARect.Top + MulDiv(i, Size, ASteps);
-      PaintRect.Bottom := ARect.Top + MulDiv(i + 1, Size, ASteps);
-
-      ACanvas.Brush.Color := RGB(StartColorR + MulDiv(i, DiffColorR,
-        ASteps - 1), StartColorG + MulDiv(i, DiffColorG, ASteps - 1),
-        StartColorB + MulDiv(i, DiffColorB, ASteps - 1));
-
-      ACanvas.FillRect(PaintRect);
-    end;
-  end;
-end;
 
 function CeilOfIntDiv(Dividend, Divisor: Cardinal): Integer;
 Var


### PR DESCRIPTION
Mixing GDI and Direct2D in the same paint cycle could cause flicker and was less efficient.  With this PR all painting is done with Direct2d/DirectWrite.

Also
- Reverted DrawIndentGuides "optimization".
- Remove "fix" of #161 (Fix #166) by popular demand.
- Rationalized default options (removed eoScrollPastEOL).
- Updated demos