### PR TITLE
Calling a non-deprecated variant of TStream.Seek

### DIFF
--- a/Source/SynUnicode.pas
+++ b/Source/SynUnicode.pas
@@ -234,7 +234,7 @@ begin
   begin
     SetLength(Buffer, BufferSize);
     Stream.Read(Buffer, 0, BufferSize);
-    Stream.Seek(-BufferSize, soFromCurrent);
+    Stream.Seek(-BufferSize, soCurrent);
 
     { first search for BOM }
     Encoding := nil;
@@ -398,7 +398,7 @@ begin
   begin
     Setlength(Buffer, Length(Preamble));
     Stream.Read(Buffer, 0, Length(Preamble));
-    Stream.Seek(-Length(Preamble), soFromCurrent);
+    Stream.Seek(-Length(Preamble), soCurrent);
     if TBytesEqual(Preamble, Buffer, Length(Preamble)) then
     begin
       WithBOM := True;
@@ -411,7 +411,7 @@ begin
   begin
     Setlength(Buffer, Length(Preamble));
     Stream.Read(Buffer, 0, Length(Preamble));
-    Stream.Seek(-Length(Preamble), soFromCurrent);
+    Stream.Seek(-Length(Preamble), soCurrent);
     if TBytesEqual(Preamble, Buffer, Length(Preamble)) then
     begin
       WithBOM := True;


### PR DESCRIPTION
Current code calls an outdated variant of Seek with Word as the last parameter type, which gives warnings while building my app with SynEdit. 

See System.Classes.pas for details.