### PR TITLE
TSynExporterHTML

### DIFF
--- a/Source/SynExportHTML.pas
+++ b/Source/SynExportHTML.pas
@@ -3,13 +3,10 @@ The contents of this file are subject to the Mozilla Public License
 Version 1.1 (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 http://www.mozilla.org/MPL/
-
 Software distributed under the License is distributed on an "AS IS" basis,
 WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 the specific language governing rights and limitations under the License.
-
 The Original Code is: SynExportHTML.pas, released 2000-04-16.
-
 The Original Code is partly based on the mwHTMLExport.pas file from the
 mwEdit component suite by Martin Waldenburg and other developers, the Initial
 Author of this file is Michael Hieke.
@@ -18,9 +15,7 @@ Portions created by James D. Jacobson are Copyright 1999 Martin Waldenburg.
 Changes to emit XHTML 1.0 Strict complying code by Maël Hörz.
 Unicode translation by Maël Hörz.
 All Rights Reserved.
-
 Contributors to the SynEdit project are listed in the Contributors.txt file.
-
 Alternatively, the contents of this file may be used under the terms of the
 GNU General Public License Version 2 or later (the "GPL"), in which case
 the provisions of the GPL are applicable instead of those above.
@@ -30,12 +25,9 @@ under the MPL, indicate your decision by deleting the provisions above and
 replace them with the notice and other provisions required by the GPL.
 If you do not delete the provisions above, a recipient may use your version
 of this file under either the MPL or the GPL.
-
 $Id: SynExportHTML.pas,v 1.19.2.7 2008/09/14 16:24:59 maelh Exp $
-
 You may retrieve the latest version of this file at the SynEdit home page,
 located at http://SynEdit.SourceForge.net
-
 Known Issues:
 -------------------------------------------------------------------------------}
 
@@ -60,6 +52,7 @@ type
     FStyleNameCache: TDictionary<TSynHighlighterAttributes, string>;
     FStyleValueCache: TDictionary<TSynHighlighterAttributes, string>;
     FAddNewLine: Boolean;
+    FSuppressFragmentInfo: boolean;
     function AttriToCSS(Attri: TSynHighlighterAttributes;
       UniqueAttriName: string): string;
     function AttriToCSSCallback(Highlighter: TSynCustomHighlighter;
@@ -106,6 +99,8 @@ type
       write FCreateHTMLFragment default False;
     property InlineCSS: boolean read FInlineCSS
       write FInlineCSS default False;
+    property SuppressFragmentInfo: boolean read FSuppressFragmentInfo
+      write FSuppressFragmentInfo default False;
     property DefaultFilter;
     property Encoding;
     property Font;
@@ -353,9 +348,10 @@ end;
 function TSynExporterHTML.GetFooter: string;
 begin
   Result := '';
-  if FCreateHTMLFragment then
+  if FCreateHTMLFragment and not FSuppressFragmentInfo then
     Result := Result + FragmentEndText;
-  Result := Result + #13#10 + BodyEndText + HTMLEndText;
+  if not FCreateHTMLFragment then
+    Result := Result + #13#10 + BodyEndText + HTMLEndText;
 end;
 
 function TSynExporterHTML.GetFormatName: string;
@@ -396,13 +392,16 @@ begin
   end
   else
   begin
-    StartHTMLPos := DetailLength;
-    StartFragmentPos := DetailLength + Header.Length + FragmentStartText.Length;
-    EndFragmentPos := StartFragmentPos + GetBufferSize;
-    EndHTMLPos := EndFragmentPos + GetFooter.Length;
-    Result := Format(DetailSection,
-      [StartHTMLPos, EndHTMLPos, StartFragmentPos, EndFragmentPos]);
-    Result := Result + Header + FragmentStartText;
+    if not FSuppressFragmentInfo then
+    begin
+      StartHTMLPos := DetailLength;
+      StartFragmentPos := DetailLength + Header.Length + FragmentStartText.Length;
+      EndFragmentPos := StartFragmentPos + GetBufferSize;
+      EndHTMLPos := EndFragmentPos + GetFooter.Length;
+      Result := Format(DetailSection,
+        [StartHTMLPos, EndHTMLPos, StartFragmentPos, EndFragmentPos]);
+      Result := Result + Header + FragmentStartText;
+    end;
   end;
 end;
 


### PR DESCRIPTION
New property: SuppressHTMLFragmentInfo - it suppresses information like position, length e.t.c. Generates pure HTML code. False as Default, so it has no influence of existing code
Fix: in case of HTML fragment is adds /body /html tags