### PR TITLE
[XE12.3] Fix link error: '[ilink32 Error] Error: Unresolved external' for SynEditCR

### DIFF
--- a/Packages/11AndAbove/CBuilder/SynEditCR.cbproj
+++ b/Packages/11AndAbove/CBuilder/SynEditCR.cbproj
@@ -128,6 +128,9 @@
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <ItemGroup>
+        <LibFiles Include="UIAutomationCore.lib" Condition="'$(Platform)'=='Win32'">
+            <BuildOrder>47</BuildOrder>
+        </LibFiles>
         <PackageImport Include="bindengine.bpi">
             <BuildOrder>117</BuildOrder>
         </PackageImport>


### PR DESCRIPTION
[XE12.3] Fix build error: [ilink32 Error] Error: Unresolved external …

brcc32 command line for ".\Win32\Release\SynEditCR.vrc"
...
[ilink32 Error] Error: Unresolved external 'UiaGetReservedNotSupportedValue' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaHostProviderFromHwnd' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaRaiseAutomationPropertyChangedEvent' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaClientsAreListening' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaRaiseAutomationEvent' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaDisconnectProvider' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNACCESSIBILITY.OBJ
[ilink32 Error] Error: Unresolved external 'UiaReturnRawElementProvider' referenced from C:\DEVELOP\SYNEDIT.GIT\PACKAGES\11ANDABOVE\CPP\WIN32\RELEASE\SYNEDIT.OBJ
[ilink32 Error] Error: Unable to perform link