### PR TITLE
Fix Win64 type mismatch in IDataObject.HasFormat

### DIFF
--- a/Source/Highlighters/SynHighlighterDelphi.pas
+++ b/Source/Highlighters/SynHighlighterDelphi.pas
@@ -605,7 +605,13 @@ begin
   // Handle Multiline String State
   if fRange = rsMultilineString then
   begin
-    StringProc;
+    case fLine[Run] of
+      #0: NullProc;
+      #10: LFProc;
+      #13: CRProc;
+    else
+      StringProc;
+    end;
     Exit;
   end;
 

--- a/Source/SynEditDataObject.pas
+++ b/Source/SynEditDataObject.pas
@@ -132,7 +132,7 @@ function HasFormat(DataObject: IDataObject; Format: TClipFormat):Boolean;
 var
   FormatEnumerator: IEnumFormatEtc;
   FormatEtc: TFormatEtc;
-  Returned: NativeInt;
+  Returned: Longint;
 begin
   Result := False;
   if (DataObject.EnumFormatEtc (DATADIR_GET, FormatEnumerator) = S_OK) then begin


### PR DESCRIPTION
Here the code was passing a pointer to a NativeInt variable (which can be either a 32 or 64 bit integer) to a function that explicitly expects a pointer to a LongInt variable (32 bit) regardless of the architecture

The COM API signature is Next(celt, out rgelt, pceltFetched: PLongint), so passing @Returned where Returned was NativeInt produced an incompatible types error (PLongInt vs Pointer) on strict Win64 builds.

I noticed it only because I included this unit in a project where i did enable more strict type pointer checking for the @ operator, and it became a compilation error