### PR TITLE
DisplayFlowControl - allow setting custom `Break` and `Continue` colors  (prefer green)

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -3320,7 +3320,7 @@ begin
         if (FlowControl <> fcNone) and (FullRowFG = clNone) and
           (CharOffset + LastChar = SLine.Length + 2)
         then
-          Layout.SetFontColor(FDisplayFlowControl.Color, LastChar - FirstChar + 1, 1);
+          Layout.SetFontColor(FDisplayFlowControl.GetColorForControl(FlowControl), LastChar - FirstChar + 1, 1);
       end;
     end;
 

--- a/Source/SynEditMiscClasses.pas
+++ b/Source/SynEditMiscClasses.pas
@@ -12,7 +12,7 @@
   The Original Code is based on the mwSupportClasses.pas file from the
   mwEdit component suite by Martin Waldenburg and other developers, the Initial
   Author of this file is Michael Hieke.
-  Unicode translation by Maël Hörz.
+  Unicode translation by MaÃ«l HÃ¶rz.
   All Rights Reserved.
 
   Contributors to the SynEdit and mwEdit projects are listed in the
@@ -852,11 +852,17 @@ type
   private
     FEnabled: Boolean;
     FColor: TColor;
+    FBreakColor: TColor;
+    FContinueColor: TColor;
+  public
+    function GetColorForControl(FC: TSynFlowControl): TColor;
   published
     constructor Create;
     procedure Assign(aSource: TPersistent); override;
     property Enabled: Boolean read FEnabled write FEnabled default True;
-    property Color: TColor read FColor write FColor default $0045FF; //clWebOrangeRed
+    property Color: TColor read FColor write FColor default $0045FF; //clWebOrangeRed (exit)
+    property BreakColor: TColor read FBreakColor write FBreakColor default $0045FF;
+    property ContinueColor: TColor read FContinueColor write FContinueColor default $0045FF;
   end;
 
    {$ENDREGION 'TSynDisplayFlowControl'}
@@ -4256,6 +4262,8 @@ begin
   begin
     FEnabled := TSynDisplayFlowControl(aSource).Enabled;
     FColor := TSynDisplayFlowControl(aSource).Color;
+    FBreakColor := TSynDisplayFlowControl(aSource).BreakColor;
+    FContinueColor := TSynDisplayFlowControl(aSource).ContinueColor;
   end
   else
     inherited;
@@ -4265,7 +4273,19 @@ constructor TSynDisplayFlowControl.Create;
 begin
   inherited;
   FEnabled := True;
-  FColor := $0045FF;  // clWebOrangeRed
+  FColor := $0045FF;  // clWebOrangeRed (exit default)
+  FBreakColor := $0045FF;
+  FContinueColor := $0045FF;
+end;
+
+function TSynDisplayFlowControl.GetColorForControl(FC: TSynFlowControl): TColor;
+begin
+  case FC of
+    fcBreak:    Result := FBreakColor;
+    fcContinue: Result := FContinueColor;
+  else
+    Result := FColor; // fcExit and fcNone
+  end;
 end;
 
 {$ENDREGION 'TSynDisplayFlowControl'}

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,6 @@
+`2026.05.08` Currently, this is just a temp repo created for a single [PR-297](https://github.com/TurboPack/SynEdit/pull/297)... which adds the ability to set the ControlFlow color to Green for `Continue` and `Break` statements
+
+
 # TurboPack SynEdit
 
 The master branch remains compatible with Delphi 12 Athens or later. You can also access the [11 Alexandira](https://github.com/TurboPack/SynEdit/tree/11Alexandria), [10.3 Rio](https://github.com/TurboPack/SynEdit/releases/tag/103RIO), [10.2 Tokyo](https://github.com/TurboPack/SynEdit/releases/tag/102Tokyo) and [10.1 Berlin](https://github.com/TurboPack/SynEdit/releases/tag/101Berlin) releases. Keep in mind they don't have the latest updates.


### PR DESCRIPTION
SynEditMiscClasses.pas:
  - Added FBreakColor, FContinueColor fields  (using same default red color)
  - Added GetColorForControl(FC) public method that handles per-flow control type
  - Published BreakColor and ContinueColor properties (default to same $0045FF for backward compatibility)
  - Updated Assign and Create to include new fields

+One liner in SynEdit.pas:
  - Line 3323: FDisplayFlowControl.Color → FDisplayFlowControl.GetColorForControl(FlowControl)

Code remains backward compatible -- existing code that only sets `Color` gets the same color for all three types. New code can set `BreakColor` and `ContinueColor` independently.

```pascal
  SourceMemo.DisplayFlowControl.Enabled := True;
  SourceMemo.DisplayFlowControl.BreakColor := clGreen;    // break: green
  SourceMemo.DisplayFlowControl.ContinueColor := clGreen; // continue: green
```

Simply a preference thing... as it looks more like RAD Studio to have these 2 in green.  Arrows are a little thinner though.