### PR TITLE
Update SynHighlighterRuby.pas

### DIFF
--- a/Source/Highlighters/SynHighlighterRuby.pas
+++ b/Source/Highlighters/SynHighlighterRuby.pas
@@ -12,7 +12,7 @@ The Original Code is: SynHighlighterRuby.pas, released 2001-11-13.
 The Initial Author of this file is Stefan Ascher.
 Portions by Jan Verhoeven (http://jansfreeware.com/jfdelphi.htm)
 "Heredoc" syntax highlighting implementation by Marko Njezic.
-Unicode translation by Maël Hörz.
+Unicode translation by MaÃ«l HÃ¶rz.
 All Rights Reserved.
 
 Contributors to the SynEdit and mwEdit projects are listed in the
@@ -53,10 +53,11 @@ uses
 
 type
   TtkTokenKind = (tkComment, tkIdentifier, tkKey, tkNull, tkNumber, tkSecondKey,
-    tkSpace, tkString, tkSymbol, tkUnknown);
+    tkSpace, tkString, tkSymbol, tkUnknown, tkVariable, tkConstant,
+    tkAttribute, tkRegex);
 
 {$IFDEF SYN_HEREDOC}
-  TRangeState = (rsUnknown, rsHeredoc, rsIndentedHeredoc);
+  TRangeState = (rsUnknown, rsHeredoc, rsIndentedHeredoc, rsBlockComment);
 
   TRangePointer = packed record
     case Boolean of
@@ -64,7 +65,7 @@ type
       False: (Range: Byte; Length: Byte; Checksum: Word);
     end;
 {$ELSE}
-  TRangeState = (rsUnknown);
+  TRangeState = (rsUnknown, rsBlockComment);
 {$ENDIF}
 
 type
@@ -78,6 +79,10 @@ type
     FTokenID: TtkTokenKind;
     fStringAttri: TSynHighlighterAttributes;
     fSymbolAttri: TSynHighlighterAttributes;
+    fVariableAttri: TSynHighlighterAttributes;
+    fConstantAttri: TSynHighlighterAttributes;
+    fAttributeAttri: TSynHighlighterAttributes;
+    fRegexAttri: TSynHighlighterAttributes;
     fKeyAttri: TSynHighlighterAttributes;
     fSecondKeyAttri: TSynHighlighterAttributes;
     fNumberAttri: TSynHighlighterAttributes;
@@ -86,19 +91,32 @@ type
     fIdentifierAttri: TSynHighlighterAttributes;
     fKeyWords: TStrings;
     fSecondKeys: TStrings;
+    procedure BacktickProc;
+    procedure BlockCommentProc;
     procedure BraceOpenProc;
+    procedure ColonProc;
     procedure PointCommaProc;
     procedure CRProc;
+    procedure EqualProc;
     procedure IdentProc;
     procedure LFProc;
     procedure LowerProc;
     procedure NullProc;
     procedure NumberProc;
+    procedure PercentProc;
+    procedure ReadDelimitedLiteral(AOpenDelim, ACloseDelim: WideChar;
+      AAllowNesting: Boolean; ATokenID: TtkTokenKind);
+    procedure RegexpProc;
     procedure RoundOpenProc;
     procedure SlashProc;
     procedure SpaceProc;
     procedure StringProc;
+    procedure SymbolProc;
     procedure UnknownProc;
+    procedure VariableProc;
+    function CanStartRegexp: Boolean;
+    function IsAtLineStart: Boolean;
+    function LineStartsWith(const AText: string): Boolean;
 {$IFDEF SYN_HEREDOC}
     procedure HeredocProc;
 {$ENDIF}
@@ -142,6 +160,14 @@ type
       write fStringAttri;
     property SymbolAttri: TSynHighlighterAttributes read fSymbolAttri
       write fSymbolAttri;
+    property VariableAttri: TSynHighlighterAttributes read fVariableAttri
+      write fVariableAttri;
+    property ConstantAttri: TSynHighlighterAttributes read fConstantAttri
+      write fConstantAttri;
+    property AttributeAttri: TSynHighlighterAttributes read fAttributeAttri
+      write fAttributeAttri;
+    property RegexAttri: TSynHighlighterAttributes read fRegexAttri
+      write fRegexAttri;
   end;
 
 implementation
@@ -151,104 +177,205 @@ uses
   SynEditStrConst;
 
 const
-  RubyKeysCount = 43;
-  RubyKeys: array[1..RubyKeysCount] of string = (
-    'alias', 'attr', 'begin', 'break', 'case', 'class', 'def', 'do', 'else',
-    'elsif', 'end', 'ensure', 'exit', 'extend', 'false', 'for', 'gets', 'if',
-    'in', 'include', 'load', 'loop', 'module', 'next', 'nil', 'not', 'print',
-    'private', 'public', 'puts', 'raise', 'redo', 'require', 'rescue', 'retry',
-    'return', 'self', 'then', 'true', 'unless', 'when', 'while', 'yield');
+  RubyKeywordList =
+    'BEGIN END __ENCODING__ __FILE__ __LINE__ ' +
+    'alias and begin break case class def defined? do else elsif end ensure ' +
+    'false for if in module next nil not or redo rescue retry return self ' +
+    'super then true undef unless until when while yield';
+
+  RubySecondKeywordList =
+    'ARGF ARGV DATA ENV STDERR STDIN STDOUT TOPLEVEL_BINDING ' +
+    'RUBY_COPYRIGHT RUBY_DESCRIPTION RUBY_ENGINE RUBY_PATCHLEVEL ' +
+    'RUBY_PLATFORM RUBY_RELEASE_DATE RUBY_REVISION RUBY_VERSION ' +
+    'Array BasicObject Binding Class Comparable Complex Data Dir Encoding ' +
+    'Enumerable Enumerator Exception FalseClass Fiber File Float GC Hash IO ' +
+    'Integer Kernel MatchData Math Method Module Mutex NilClass Numeric Object ' +
+    'Process Proc Queue Random Range Rational Regexp RubyVM Signal SizedQueue ' +
+    'StandardError String Struct Symbol Thread Time TracePoint TrueClass ' +
+    'ArgumentError EncodingError FiberError IOError IndexError Interrupt ' +
+    'KeyError LoadError LocalJumpError NameError NoMemoryError NoMethodError ' +
+    'NotImplementedError RangeError RegexpError RuntimeError ScriptError ' +
+    'SecurityError SignalException SyntaxError SystemCallError SystemExit ' +
+    'SystemStackError ThreadError TypeError ZeroDivisionError ' +
+    '__callee__ __dir__ __method__ abort alias_method append_features ' +
+    'at_exit attr attr_accessor attr_reader attr_writer binding block_given? ' +
+    'call caller caller_locations catch chomp chop const_defined? const_get ' +
+    'const_missing const_set constants define_method delete detect display dup ' +
+    'each each_byte each_char each_cons each_entry each_key each_line each_pair ' +
+    'each_slice each_value each_with_index empty? enum_for eql? equal? eval ' +
+    'exec exit exit! extend fail fetch find first fork format freeze frozen? ' +
+    'gem gets global_variables grep group_by has_key? include include? included ' +
+    'inherited initialize inject inspect instance_eval instance_exec is_a? ' +
+    'itself lambda last length load local_variables loop map method method_missing ' +
+    'methods module_function new nil? object_id open p prepend print printf private ' +
+    'private_class_method proc protected public public_class_method putc puts ' +
+    'raise rand readline readlines reject remove_method require require_relative ' +
+    'respond_to? select send set_trace_func singleton_class size sleep sort ' +
+    'sort_by spawn sprintf super_method syscall system tap test then throw ' +
+    'to_a to_enum to_h to_i to_s trace_var trap untrace_var warn zip';
+
+procedure AddSpaceSeparatedWords(AList: TStrings; const AWords: string);
+begin
+  ExtractStrings([' ', #9, #10, #13], [], PChar(AWords), AList);
+end;
+
+function IsRubyIdentStart(AChar: WideChar): Boolean;
+begin
+  case AChar of
+    '_', 'A'..'Z', 'a'..'z':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsRubyIdentChar(AChar: WideChar): Boolean;
+begin
+  case AChar of
+    '_', '0'..'9', 'A'..'Z', 'a'..'z':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsRubyHexChar(AChar: WideChar): Boolean;
+begin
+  case AChar of
+    '_', '0'..'9', 'A'..'F', 'a'..'f':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsRubyDecChar(AChar: WideChar): Boolean;
+begin
+  case AChar of
+    '_', '0'..'9':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsPercentLiteralType(AChar: WideChar): Boolean;
+begin
+  case AChar of
+    'q', 'Q', 'w', 'W', 'i', 'I', 'r', 's', 'x':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function IsLiteralDelimiter(AChar: WideChar): Boolean;
+begin
+  Result := (AChar > #32) and not IsRubyIdentChar(AChar);
+end;
+
+function MatchingDelimiter(AOpenDelim: WideChar): WideChar;
+begin
+  case AOpenDelim of
+    '(':
+      Result := ')';
+    '[':
+      Result := ']';
+    '{':
+      Result := '}';
+    '<':
+      Result := '>';
+  else
+    Result := AOpenDelim;
+  end;
+end;
 
 function TSynRubySyn.IsKeyword(const AKeyword: string): Boolean;
-var
-  First, Last, I, Compare: TSynNativeInt;
-  Token: string;
 begin
-  First := 0;
-  Last := fKeywords.Count - 1;
-  Result := False;
-  Token := SysUtils.AnsiUpperCase(AKeyword);
-
-  while First <= Last do
-  begin
-    I := (First + Last) shr 1;
-    Compare := CompareStr(fKeywords.ItemsNative[I], Token);
-    if Compare = 0 then
-    begin
-      Result := True;
-      Break;
-    end
-    else if Compare < 0 then
-      First := I + 1
-    else
-      Last := I - 1;
-  end;
+  Result := fKeywords.IndexOf(AKeyword) >= 0;
 end; { IsKeyWord }
 
 function TSynRubySyn.IsSecondKeyWord(aToken: string): Boolean;
-var
-  First, Last, I, Compare: TSynNativeInt;
-  Token: string;
 begin
-  First := 0;
-  Last := fSecondKeys.Count - 1;
-  Result := False;
-  Token := SysUtils.AnsiUpperCase(aToken);
-  while First <= Last do
-  begin
-    I := (First + Last) shr 1;
-    Compare := CompareStr(fSecondKeys.ItemsNative[i], Token);
-    if Compare = 0 then
-    begin
-      Result := True;
-      Break;
-    end
-    else if Compare < 0 then
-      First := I + 1
-    else
-      Last := I - 1;
-  end;
+  Result := fSecondKeys.IndexOf(aToken) >= 0;
 end; { IsSecondKeyWord }
 
 constructor TSynRubySyn.Create(AOwner: TComponent);
-var
-  I: TSynNativeInt;
 begin
   inherited Create(AOwner);
 
-  fCaseSensitive := False;
+  // Ruby is case-sensitive.  The original highlighter upper-cased tokens but
+  // stored lower-case keywords, so many real Ruby keywords were never matched.
+  fCaseSensitive := True;
 
   fKeyWords := TStringList.Create;
-  TStringList(fKeyWords).Sorted := True;
-  TStringList(fKeyWords).Duplicates := dupIgnore;
+  with TStringList(fKeyWords) do
+  begin
+    Sorted := True;
+    Duplicates := dupIgnore;
+    CaseSensitive := True;
+  end;
+
   fSecondKeys := TStringList.Create;
-  TStringList(fSecondKeys).Sorted := True;
-  TStringList(fSecondKeys).Duplicates := dupIgnore;
-  if not (csDesigning in ComponentState) then
-    for I := 1 to RubyKeysCount do
-      fKeyWords.Add(RubyKeys[I]);
+  with TStringList(fSecondKeys) do
+  begin
+    Sorted := True;
+    Duplicates := dupIgnore;
+    CaseSensitive := True;
+  end;
+
+  AddSpaceSeparatedWords(fKeyWords, RubyKeywordList);
+  AddSpaceSeparatedWords(fSecondKeys, RubySecondKeywordList);
 
   fCommentAttri := TSynHighlighterAttributes.Create(SYNS_AttrComment, SYNS_FriendlyAttrComment);
-  fCommentAttri.Foreground := clMaroon;
+  fCommentAttri.Foreground := clGreen;
+  fCommentAttri.Style := [fsItalic];
   AddAttribute(fCommentAttri);
+
   fIdentifierAttri := TSynHighlighterAttributes.Create(SYNS_AttrIdentifier, SYNS_FriendlyAttrIdentifier);
   AddAttribute(fIdentifierAttri);
+
   fKeyAttri := TSynHighlighterAttributes.Create(SYNS_AttrReservedWord, SYNS_FriendlyAttrReservedWord);
   fKeyAttri.Foreground := clBlue;
+  fKeyAttri.Style := [fsBold];
   AddAttribute(fKeyAttri);
+
   fSecondKeyAttri := TSynHighlighterAttributes.Create(SYNS_AttrSecondReservedWord, SYNS_FriendlyAttrSecondReservedWord);
+  fSecondKeyAttri.Foreground := clTeal;
   AddAttribute(fSecondKeyAttri);
+
   fNumberAttri := TSynHighlighterAttributes.Create(SYNS_AttrNumber, SYNS_FriendlyAttrNumber);
-  fNumberAttri.Foreground := clGreen;
+  fNumberAttri.Foreground := clFuchsia;
   AddAttribute(fNumberAttri);
+
   fSpaceAttri := TSynHighlighterAttributes.Create(SYNS_AttrSpace, SYNS_FriendlyAttrSpace);
   AddAttribute(fSpaceAttri);
+
   fStringAttri := TSynHighlighterAttributes.Create(SYNS_AttrString, SYNS_FriendlyAttrString);
-  fStringAttri.Foreground := clPurple;
+  fStringAttri.Foreground := clRed;
   AddAttribute(fStringAttri);
+
   fSymbolAttri := TSynHighlighterAttributes.Create(SYNS_AttrSymbol, SYNS_FriendlyAttrSymbol);
-  fSymbolAttri.Foreground := clBlue;
+  fSymbolAttri.Foreground := clNavy;
   AddAttribute(fSymbolAttri);
+
+  fVariableAttri := TSynHighlighterAttributes.Create(SYNS_AttrVariable, SYNS_FriendlyAttrVariable);
+  fVariableAttri.Foreground := clTeal;
+  AddAttribute(fVariableAttri);
+
+  fConstantAttri := TSynHighlighterAttributes.Create(SYNS_AttrConstant, SYNS_FriendlyAttrConstant);
+  fConstantAttri.Foreground := clNavy;
+  fConstantAttri.Style := [fsBold];
+  AddAttribute(fConstantAttri);
+
+  fAttributeAttri := TSynHighlighterAttributes.Create(SYNS_AttrAttribute, SYNS_FriendlyAttrAttribute);
+  fAttributeAttri.Foreground := clTeal;
+  AddAttribute(fAttributeAttri);
+
+  fRegexAttri := TSynHighlighterAttributes.Create('RegularExpression', 'Regular Expression');
+  fRegexAttri.Foreground := clPurple;
+  AddAttribute(fRegexAttri);
+
   SetAttributesOnChange(DefHighlightChange);
 
   fRange := rsUnknown;
@@ -284,16 +411,34 @@ begin
 end;
 
 procedure TSynRubySyn.IdentProc;
+var
+  Token: string;
 begin
   while IsIdentChar(fLine[Run]) do Inc(Run);
-  if IsKeyWord(GetToken) then
+
+  // Ruby method names and the reserved word defined? may end with ? or !.
+  if FLine[Run] in [WideChar('?'), WideChar('!')] then
+    Inc(Run);
+
+  Token := GetToken;
+  if IsKeyWord(Token) then
   begin
     fTokenId := tkKey;
     Exit;
-  end
-  else fTokenId := tkIdentifier;
-  if IsSecondKeyWord(GetToken) then
+  end;
+
+  // Ruby 1.9+ keyword arguments / hash labels: name:, active:, keyword_init:
+  if (FLine[Run] = ':') and (FLine[Run + 1] <> ':') then
+  begin
+    Inc(Run);
+    fTokenId := tkAttribute;
+    Exit;
+  end;
+
+  if IsSecondKeyWord(Token) then
     fTokenId := tkSecondKey
+  else if (Token <> '') and (Token[1] in ['A'..'Z']) then
+    fTokenId := tkConstant
   else
     fTokenId := tkIdentifier;
 end;
@@ -382,28 +527,63 @@ begin
 end;
 
 procedure TSynRubySyn.NumberProc;
-
-  function IsNumberChar: Boolean;
-  begin
-    case fLine[Run] of
-      '0'..'9', '.', 'e', 'E':
-        Result := True;
-      else
-        Result := False;
-    end;
-  end;
-
+var
+  SaveRun: TSynNativeInt;
 begin
-  Inc(Run);
   fTokenID := tkNumber;
-  while IsNumberChar do
+
+  if FLine[Run] = '0' then
   begin
-    case FLine[Run] of
-      '.':
-        if FLine[Run + 1] = '.' then Break;
+    case FLine[Run + 1] of
+      'x', 'X':
+        begin
+          Inc(Run, 2);
+          while IsRubyHexChar(FLine[Run]) do Inc(Run);
+          Exit;
+        end;
+      'b', 'B':
+        begin
+          Inc(Run, 2);
+          while FLine[Run] in ['_', '0', '1'] do Inc(Run);
+          Exit;
+        end;
+      'o', 'O':
+        begin
+          Inc(Run, 2);
+          while FLine[Run] in ['_', '0'..'7'] do Inc(Run);
+          Exit;
+        end;
+      'd', 'D':
+        begin
+          Inc(Run, 2);
+          while IsRubyDecChar(FLine[Run]) do Inc(Run);
+          Exit;
+        end;
     end;
-    Inc(Run);
   end;
+
+  while IsRubyDecChar(FLine[Run]) do Inc(Run);
+
+  if (FLine[Run] = '.') and (FLine[Run + 1] <> '.') then
+  begin
+    Inc(Run);
+    while IsRubyDecChar(FLine[Run]) do Inc(Run);
+  end;
+
+  if FLine[Run] in ['e', 'E'] then
+  begin
+    SaveRun := Run;
+    Inc(Run);
+    if FLine[Run] in ['+', '-'] then Inc(Run);
+    if FLine[Run] in ['0'..'9'] then
+      while IsRubyDecChar(FLine[Run]) do Inc(Run)
+    else
+      Run := SaveRun;
+  end;
+
+  // Ruby rational / imaginary suffixes: 1r, 2.5r, 3i
+  if FLine[Run] in ['r', 'i'] then
+    Inc(Run);
 end;
 
 procedure TSynRubySyn.RoundOpenProc;
@@ -415,27 +595,26 @@ end;
 procedure TSynRubySyn.SlashProc;
 begin
   case FLine[Run] of
+    '#':
+      begin
+        fTokenID := tkComment;
+        while FLine[Run] <> #0 do
+        begin
+          case FLine[Run] of
+            #10, #13: Break;
+          end;
+          Inc(Run);
+        end;
+      end;
     '/':
       begin
-        Inc(Run);
-        fTokenId := tkSymbol;
-      end;
-    '*':
-      begin
-        Inc(Run);
-        fTokenId := tkSymbol;
+        if CanStartRegexp and not IsLineEnd(Run + 1) then
+          RegexpProc
+        else
+          SymbolProc;
       end;
   else
-    begin
-      fTokenID := tkComment;
-      while FLine[Run] <> #0 do
-      begin
-        case FLine[Run] of
-          #10, #13: Break;
-        end;
-        Inc(Run);
-      end;
-    end;
+    SymbolProc;
   end;
 end;
 
@@ -450,33 +629,305 @@ procedure TSynRubySyn.StringProc;
 var
   QuoteChar: WideChar;
 begin
-// Ha, ha, Strings in Ruby (could be anything)!!!!
-
-//There are three more ways to construct string literals: %q, %Q, and ``here
-//documents.''
-//
-//%q and %Q start delimited single- and double-quoted strings.
-//
-//%q/general single-quoted string/ » general single-quoted string
-//%Q!general double-quoted string! » general double-quoted string
-//%Q{Seconds/day: #{24*60*60}}     » Seconds/day: 86400
-//
-//The character following the ``q'' or ``Q'' is the delimiter. If it is an
-//opening bracket, brace, parenthesis, or less-than sign, the string is read
-//until the matching close symbol is found. Otherwise the string is read until
-//the next occurrence of the same delimiter.
-
   fTokenID := tkString;
   QuoteChar := FLine[Run];      // either " or '
-  if (FLine[Run + 1] = QuoteChar) and (FLine[Run + 2] = QuoteChar)
-    then Inc(Run, 2);
-  repeat
-    case FLine[Run] of
-      #0, #10, #13: Break;
+  Inc(Run);
+
+  while not IsLineEnd(Run) do
+  begin
+    if FLine[Run] = '\' then
+    begin
+      Inc(Run);
+      if not IsLineEnd(Run) then Inc(Run);
+      Continue;
     end;
+
+    if FLine[Run] = QuoteChar then
+    begin
+      Inc(Run);
+      Break;
+    end;
+
     Inc(Run);
-  until FLine[Run] = QuoteChar;
-  if FLine[Run] <> #0 then Inc(Run);
+  end;
+end;
+
+procedure TSynRubySyn.SymbolProc;
+begin
+  Inc(Run);
+  fTokenID := tkSymbol;
+end;
+
+procedure TSynRubySyn.VariableProc;
+begin
+  fTokenID := tkVariable;
+
+  // Instance variables, class variables and globals: @x, @@x, $x, $1, $!
+  Inc(Run);
+  if (FLine[fTokenPos] = '@') and (FLine[Run] = '@') then
+    Inc(Run);
+
+  if IsRubyIdentStart(FLine[Run]) then
+  begin
+    while IsRubyIdentChar(FLine[Run]) do Inc(Run);
+    if FLine[Run] in [WideChar('?'), WideChar('!')] then Inc(Run);
+  end
+  else if FLine[fTokenPos] = '$' then
+  begin
+    if FLine[Run] in ['0'..'9'] then
+      while FLine[Run] in ['0'..'9'] do Inc(Run)
+    else if not IsLineEnd(Run) then
+      Inc(Run);
+  end;
+end;
+
+procedure TSynRubySyn.ColonProc;
+begin
+  if FLine[Run + 1] = ':' then
+  begin
+    Inc(Run, 2);
+    fTokenID := tkSymbol;
+  end
+  else if IsRubyIdentStart(FLine[Run + 1]) then
+  begin
+    Inc(Run);
+    while IsRubyIdentChar(FLine[Run]) do Inc(Run);
+    if FLine[Run] in [WideChar('?'), WideChar('!')] then Inc(Run);
+    fTokenID := tkAttribute;
+  end
+  else
+    SymbolProc;
+end;
+
+function TSynRubySyn.IsAtLineStart: Boolean;
+var
+  I: TSynNativeInt;
+begin
+  Result := True;
+  for I := 0 to Run - 1 do
+    if not (FLine[I] in [#$0009, #$0020]) then
+    begin
+      Result := False;
+      Exit;
+    end;
+end;
+
+function TSynRubySyn.LineStartsWith(const AText: string): Boolean;
+var
+  I, P: TSynNativeInt;
+begin
+  P := Run;
+  while FLine[P] in [#$0009, #$0020] do Inc(P);
+
+  Result := False;
+  for I := 1 to Length(AText) do
+    if FLine[P + I - 1] <> AText[I] then
+      Exit;
+
+  if not IsLineEnd(P + Length(AText)) then
+    case FLine[P + Length(AText)] of
+      #9, #32: ;
+    else
+      Exit;
+    end;
+
+  Result := True;
+end;
+
+procedure TSynRubySyn.EqualProc;
+begin
+  if IsAtLineStart and LineStartsWith('=begin') then
+  begin
+    fTokenID := tkComment;
+    fRange := rsBlockComment;
+    while not IsLineEnd(Run) do Inc(Run);
+  end
+  else
+    SymbolProc;
+end;
+
+procedure TSynRubySyn.BlockCommentProc;
+begin
+  fTokenID := tkComment;
+  if LineStartsWith('=end') then
+    fRange := rsUnknown;
+  while not IsLineEnd(Run) do Inc(Run);
+end;
+
+function TSynRubySyn.CanStartRegexp: Boolean;
+var
+  I: TSynNativeInt;
+begin
+  I := Run - 1;
+  while (I >= 0) and (FLine[I] in [#$0009, #$0020]) do Dec(I);
+  if I < 0 then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  case FLine[I] of
+    '(', '[', '{', '=', ',', ';', ':', '!', '~', '?', '&', '|', '^', '+', '-', '*', '%', '<', '>':
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+procedure TSynRubySyn.RegexpProc;
+var
+  Escaped, InCharClass: Boolean;
+begin
+  fTokenID := tkRegex;
+  Escaped := False;
+  InCharClass := False;
+
+  Inc(Run); // leading /
+  while not IsLineEnd(Run) do
+  begin
+    if Escaped then
+    begin
+      Escaped := False;
+      Inc(Run);
+      Continue;
+    end;
+
+    case FLine[Run] of
+      '\':
+        begin
+          Escaped := True;
+          Inc(Run);
+          Continue;
+        end;
+      '[':
+        InCharClass := True;
+      ']':
+        InCharClass := False;
+      '/':
+        if not InCharClass then
+        begin
+          Inc(Run);
+          while FLine[Run] in ['a'..'z', 'A'..'Z'] do Inc(Run);
+          Exit;
+        end;
+    end;
+
+    Inc(Run);
+  end;
+end;
+
+procedure TSynRubySyn.ReadDelimitedLiteral(AOpenDelim, ACloseDelim: WideChar;
+  AAllowNesting: Boolean; ATokenID: TtkTokenKind);
+var
+  Depth: Integer;
+  Escaped: Boolean;
+begin
+  fTokenID := ATokenID;
+  Depth := 1;
+  Escaped := False;
+
+  while not IsLineEnd(Run) do
+  begin
+    if Escaped then
+    begin
+      Escaped := False;
+      Inc(Run);
+      Continue;
+    end;
+
+    if FLine[Run] = '\' then
+    begin
+      Escaped := True;
+      Inc(Run);
+      Continue;
+    end;
+
+    if AAllowNesting and (FLine[Run] = AOpenDelim) then
+    begin
+      Inc(Depth);
+      Inc(Run);
+      Continue;
+    end;
+
+    if FLine[Run] = ACloseDelim then
+    begin
+      Dec(Depth);
+      Inc(Run);
+      if Depth = 0 then Break;
+      Continue;
+    end;
+
+    Inc(Run);
+  end;
+
+  if ATokenID = tkRegex then
+    while FLine[Run] in ['a'..'z', 'A'..'Z'] do Inc(Run);
+end;
+
+procedure TSynRubySyn.PercentProc;
+var
+  Prefix, OpenDelim, CloseDelim: WideChar;
+  TokenKind: TtkTokenKind;
+  AllowNesting: Boolean;
+begin
+  Prefix := #0;
+
+  if IsPercentLiteralType(FLine[Run + 1]) then
+  begin
+    Prefix := FLine[Run + 1];
+    OpenDelim := FLine[Run + 2];
+    if not IsLiteralDelimiter(OpenDelim) then
+    begin
+      SymbolProc;
+      Exit;
+    end;
+    Inc(Run, 3); // %, type and opening delimiter
+  end
+  else
+  begin
+    OpenDelim := FLine[Run + 1];
+    if not IsLiteralDelimiter(OpenDelim) then
+    begin
+      SymbolProc;
+      Exit;
+    end;
+    Inc(Run, 2); // % and opening delimiter
+  end;
+
+  CloseDelim := MatchingDelimiter(OpenDelim);
+  AllowNesting := OpenDelim in ['(', '[', '{', '<'];
+  if Prefix = 'r' then
+    TokenKind := tkRegex
+  else if Prefix = 's' then
+    TokenKind := tkAttribute
+  else
+    TokenKind := tkString;
+
+  ReadDelimitedLiteral(OpenDelim, CloseDelim, AllowNesting, TokenKind);
+end;
+
+procedure TSynRubySyn.BacktickProc;
+begin
+  fTokenID := tkString;
+  Inc(Run);
+
+  while not IsLineEnd(Run) do
+  begin
+    if FLine[Run] = '\' then
+    begin
+      Inc(Run);
+      if not IsLineEnd(Run) then Inc(Run);
+      Continue;
+    end;
+
+    if FLine[Run] = '`' then
+    begin
+      Inc(Run);
+      Break;
+    end;
+
+    Inc(Run);
+  end;
 end;
 
 procedure TSynRubySyn.UnknownProc;
@@ -549,11 +1000,13 @@ end;
 procedure TSynRubySyn.Next;
 begin
   fTokenPos := Run;
+  if fRange = rsBlockComment then
+    BlockCommentProc
 {$IFDEF SYN_HEREDOC}
-  if fRange in [rsHeredoc, rsIndentedHeredoc] then
+  else if fRange in [rsHeredoc, rsIndentedHeredoc] then
     HeredocProc
-  else
 {$ENDIF}
+  else
     NextProcedure;
   inherited;
 end;
@@ -563,14 +1016,17 @@ begin
   case fLine[Run] of
     '<': LowerProc;
     '#': SlashProc;
-    '{': BraceOpenProc;
-    ';': PointCommaProc;
+    '{', '}', '(', ')', '[', ']', ';', ',', '.', '+', '-', '*', '&', '|', '^', '~', '!', '?', '>': SymbolProc;
+    ':': ColonProc;
+    '=': EqualProc;
+    '@', '$': VariableProc;
+    '%': PercentProc;
+    '`': BacktickProc;
     #13: CRProc;
     'A'..'Z', 'a'..'z', '_': IdentProc;
     #10: LFProc;
     #0: NullProc;
     '0'..'9': NumberProc;
-    '(': RoundOpenProc;
     '/': SlashProc;
     #1..#9, #11, #12, #14..#32: SpaceProc;
     #34, #39: StringProc;
@@ -633,6 +1089,10 @@ begin
     tkSpace: Result := fSpaceAttri;
     tkString: Result := fStringAttri;
     tkSymbol: Result := fSymbolAttri;
+    tkVariable: Result := fVariableAttri;
+    tkConstant: Result := fConstantAttri;
+    tkAttribute: Result := fAttributeAttri;
+    tkRegex: Result := fRegexAttri;
     tkUnknown: Result := fSymbolAttri;
   else
     Result := nil;
@@ -675,16 +1135,7 @@ begin
 end;
 
 procedure TSynRubySyn.SetSecondKeys(const Value: TStrings);
-var
-  i: Integer;
 begin
-  if Value <> nil then
-    begin
-      Value.BeginUpdate;
-      for i := 0 to Value.Count - 1 do
-        Value[i] := SysUtils.AnsiUpperCase(Value[i]);
-      Value.EndUpdate;
-    end;
   fSecondKeys.Assign(Value);
   DefHighLightChange(nil);
 end;
@@ -702,15 +1153,20 @@ end;
 function TSynRubySyn.GetSampleSource: string;
 begin
   Result :=
-    '# Factorial'+#13#10+
-    'def fact(n)'+#13#10+
-    '  if n == 0'+#13#10+
-    '    1'+#13#10+
-    '  else'+#13#10+
-    '    n * fact(n-1)'+#13#10+
+    '# Ruby highlighter sample'+#13#10+
+    'User = Struct.new(:id, :name, :active, keyword_init: true) do'+#13#10+
+    '  def label'+#13#10+
+    '    status = active ? "active" : "inactive"'+#13#10+
+    '    "#{id}: #{name} (#{status})"'+#13#10+
     '  end'+#13#10+
     'end'+#13#10+
-    'print fact(ARGV[0].to_i), "\n"';
+    ''+#13#10+
+    'class Registry'+#13#10+
+    '  attr_reader :users'+#13#10+
+    '  def initialize(users)'+#13#10+
+    '    @users = users'+#13#10+
+    '  end'+#13#10+
+    'end';
 end;
 
 class function TSynRubySyn.GetFriendlyLanguageName: string;


### PR DESCRIPTION
**Main improvements:**

- Fixed the keyword matching bug so def, class, do, end, true, false, etc. should actually color correctly.
- Added the official Ruby reserved keywords like BEGIN, END, __FILE__, __LINE__, __ENCODING__, defined?, super, undef, etc.
- Added many Ruby built-ins, classes, exceptions, and common methods.
- Added highlighting for: @instance_variables @@class_variables $global_variables :symbols keyword_init:, name:, active: style keyword arguments constants/classes like User, Struct, Registry %q, %Q, %w, %W, %i, %I, %r, %s, %x backtick command strings basic regex literals =begin / =end block comments 
- Improved number formats like 0xFF, 0b1010, 0o755, 1.5, 1e10, 3i

**Screenshot of before:**

<img width="553" height="515" alt="ruby-before" src="https://github.com/user-attachments/assets/ca0d0dd8-beed-40be-8257-296cd1ac3d70" />

**Screenshot of after:**

<img width="562" height="478" alt="ruby-after" src="https://github.com/user-attachments/assets/51afe938-f339-49bf-a676-07639583da01" />
