### PR TITLE
Prevent accidental "Import IDE Settings" on double click

### DIFF
--- a/Source/DesignTimeEditors/SynDelphiIDEImporter.pas
+++ b/Source/DesignTimeEditors/SynDelphiIDEImporter.pas
@@ -10,8 +10,9 @@ uses
 type
   // Descends from TDefaultEditor (not TComponentEditor) on purpose: TComponentEditor.Edit
   // executes the first verb, so a plain double click in the form designer would silently
-  // overwrite every setting of the component. TDefaultEditor.Edit instead creates/jumps to
-  // the default event handler, which is the behaviour expected from a double click.
+  // overwrite the imported settings of the component (font, colors, gutter, selection, tabs
+  // and highlighting attributes). TDefaultEditor.Edit instead creates/jumps to the default
+  // event handler, which is the behaviour expected from a double click.
   TSynIDEImportEditor = class(TDefaultEditor)
   private
     function ConfirmImport(const AWhatWillBeOverwritten: string): Boolean;

--- a/Source/DesignTimeEditors/SynDelphiIDEImporter.pas
+++ b/Source/DesignTimeEditors/SynDelphiIDEImporter.pas
@@ -3,12 +3,18 @@
 interface
 
 uses
-  Classes, SysUtils, Vcl.Dialogs, Vcl.Graphics, System.Win.Registry,
+  Classes, SysUtils, System.UITypes, Vcl.Dialogs, Vcl.Graphics, System.Win.Registry,
   DesignIntf, DesignEditors, ToolsAPI,
   SynEdit, SynHighlighterDelphi, SynEditHighlighter, SynEditTypes;
 
 type
-  TSynIDEImportEditor = class(TComponentEditor)
+  // Descends from TDefaultEditor (not TComponentEditor) on purpose: TComponentEditor.Edit
+  // executes the first verb, so a plain double click in the form designer would silently
+  // overwrite every setting of the component. TDefaultEditor.Edit instead creates/jumps to
+  // the default event handler, which is the behaviour expected from a double click.
+  TSynIDEImportEditor = class(TDefaultEditor)
+  private
+    function ConfirmImport(const AWhatWillBeOverwritten: string): Boolean;
   public
     function GetVerbCount: Integer; override;
     function GetVerb(Index: Integer): string; override;
@@ -302,23 +308,37 @@ end;
 //   Editor Integration
 // =============================================================================
 
+function TSynIDEImportEditor.ConfirmImport(const AWhatWillBeOverwritten: string): Boolean;
+begin
+  Result := MessageDlg(
+    Format('Import the Delphi IDE settings into "%s"?'#13#10#13#10 +
+           'This overwrites the current %s of the component and cannot be undone.',
+           [Component.Name, AWhatWillBeOverwritten]),
+    mtWarning, [mbYes, mbNo], 0, mbNo) = mrYes;
+end;
+
 procedure TSynIDEImportEditor.ExecuteVerb(Index: Integer);
 begin
-  if Index = 0 then
-  begin
-    if Component is TSynEdit then
-    begin
-      ImportToSynEdit(TSynEdit(Component));
-      ShowMessage('Imported Editor Options (Font, Gutter, Selection, Tabs) from IDE.');
-    end
-    else if Component is TSynDelphiSyn then
-    begin
-      ImportToHighlighter(TSynDelphiSyn(Component));
-      ShowMessage('Imported Syntax Colors from IDE.');
-    end;
-    
-    if Assigned(Designer) then Designer.Modified;
-  end;
+  if Index <> 0 then
+    Exit;
+
+  if Component is TSynEdit then begin
+    if not ConfirmImport('font, colors, gutter, selection and tab settings') then
+      Exit;
+    ImportToSynEdit(TSynEdit(Component));
+    ShowMessage('Imported Editor Options (Font, Gutter, Selection, Tabs) from IDE.');
+  end
+  else if Component is TSynDelphiSyn then begin
+    if not ConfirmImport('syntax highlighting colors and font styles') then
+      Exit;
+    ImportToHighlighter(TSynDelphiSyn(Component));
+    ShowMessage('Imported Syntax Colors from IDE.');
+  end
+  else
+    Exit;
+
+  if Assigned(Designer) then
+    Designer.Modified;
 end;
 
 function TSynIDEImportEditor.GetVerb(Index: Integer): string;

--- a/What's New.md
+++ b/What's New.md
@@ -50,12 +50,15 @@ This feature is a **Design-Time Component Editor** that allows you to instantly 
 
 ***Notice:*** These settings are imported from the *registry*, so if you changed your IDE settings and haven't closed the IDE the imported values may be out of date.
 
+***Notice:*** The import **overwrites** the current font, colors, gutter, selection, tab and highlighting settings of the component, and cannot be undone. For this reason it is only available through the context menu verb described below, it is **not** triggered by double-clicking the component, and it always asks for a confirmation before proceeding.
+
 ### **Usage:**
 
 1. Open the Form Designer in Delphi.  
 2. Select a TSynEdit or TSynDelphiSyn component.  
 3. **Right-click** the component to open the context menu.  
-4. Select **"Import IDE Settings"**.
+4. Select **"Import IDE Settings"**.  
+5. Confirm the warning dialog (it defaults to **No**, so pressing Enter or Esc cancels the import).
 
 ### **Importing on TSynEdit:**
 


### PR DESCRIPTION
## Problem

`TSynIDEImportEditor` (registered for `TSynEdit` and `TSynDelphiSyn`) derives from `TComponentEditor`, whose `Edit` method executes the first verb:

```pascal
procedure TComponentEditor.Edit;
begin
  if GetVerbCount > 0 then ExecuteVerb(0);
end;
```

So a plain **double click** on the component in the form designer runs "Import IDE Settings" right away. The import silently overwrites font, colours, gutter, selection, tab width, right edge and (for `TSynDelphiSyn`) all highlighting attributes of the component. There is no confirmation, and the designer offers no undo for it, so a carefully tuned component can be wiped out by a single mis-click.

## Changes

* `TSynIDEImportEditor` now derives from `TDefaultEditor`, so a double click creates/jumps to the default event handler — the behaviour a user expects from a double click in the form designer.
* `ExecuteVerb` asks for confirmation before importing. The dialog is `mtWarning`, names the component and states what will be overwritten, and defaults to **No** so that Enter/Esc cancels.
* `Designer.Modified` is only called when the import actually took place.
* The feature itself is unchanged and still reachable through the "Import IDE Settings" verb in the component context menu.

## Notes

* Single file touched: `Source/DesignTimeEditors/SynDelphiIDEImporter.pas`.
* `System.UITypes` added to the uses clause for `mrYes` / `mbNo`.
* Compiled with Delphi 12 (`dcc32`, Win32, against `designide`) with no errors or warnings.
